### PR TITLE
Add utility methods to the base PageObject

### DIFF
--- a/addon/page-object.js
+++ b/addon/page-object.js
@@ -79,4 +79,67 @@ export default class PageObject {
 
     return this;
   }
+
+  /**
+   * Pauses a test so you can look around within a PageObject chain.
+   *
+   * ```js
+   *  test('foo', function(assert) {
+   *    new SomePage(assert)
+   *      .login()
+   *      .embiggen()
+   *      .pause()
+   *      .doStuff();
+   *  });
+   * ```
+   *
+   * @public
+   * @return {this}
+   */
+  pause() {
+    return this.andThen(() => {
+      // jshint ignore:start
+      return pauseTest();
+      // jshint ignore:end
+    });
+  }
+
+  /**
+   * Embiggens the testing container for easier inspection.
+   *
+   * @public
+   * @return {this}
+   */
+  embiggen() {
+    return this.andThen(() => {
+      $('#ember-testing-container').css({ width: '100vw', height: '100vh' });
+    });
+  }
+
+  /**
+   * Throws a breakpoint via debugger within a PageObject chain.
+   *
+   * ```js
+   *  test('foo', function(assert) {
+   *    new SomePage(assert)
+   *      .login()
+   *      .embiggen()
+   *      .debug()
+   *      .doStuff();
+   *  });
+   * ```
+   *
+   * @public
+   * @return {this}
+   */
+  debug() {
+    // jshint ignore:start
+    const context = this; // deopt so `this` is accessible
+    return this.andThen((applicationInstance) => {
+      console.info('Access the PageObject with `this`, and the application instance with `applicationInstance`.');
+      debugger;
+      eval();
+    });
+    // jshint ignore:end
+  }
 }


### PR DESCRIPTION
`pause`, `embiggen` and `debug` are sugar methods that allow for
debugging and interacting with the test container in an intermediate
step of a PageObject chain (POC).

For example, a certain acceptance test is breaking and you would like to
visually inspect the DOM within a POC. To do so:

``` js
test('it does stuff', function(assert) {
  new SomePage(assert)
    .login()
    .embiggen()
    .pause() // or debug() for a breakpoint
    .doStuff();
});
```
