### PR TITLE
Add assertHasValue and assertNotHasValue

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "preset": "ember-suave"
+}

--- a/README.md
+++ b/README.md
@@ -331,6 +331,32 @@ export default class SignupPage extends PageObject {
 }
 ```
 
+### assertHasValue()
+`assertHasValue(selector = '', text = '', message = '')`
+
+Asserts the element's value matching the selector contains the passed in text. Accepts an optional assertion message.
+
+```js
+export default class SignupPage extends PageObject {
+  assertInputName(text) {
+    return this.assertHasValue('#name', text, `input with elementId 'name' has value: ${text}`);
+  }
+}
+```
+
+### assertNotHasValue()
+`assertNotHasValue(selector = '', text = '', message = '')`
+
+Asserts the element's value matching the selector does not contain the passed in text. Accepts an optional assertion message.
+
+```js
+export default class SignupPage extends PageObject {
+  assertNotInputName(text) {
+    return this.assertNotHasValue('#name', text, `input with elementId 'name' does not have value: ${text}`);
+  }
+}
+```
+
 ## Debugging
 ### embiggen()
 `embiggen()`

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-sinon": "0.2.1",
-    "ember-suave": "1.0.0",
+    "ember-suave": "1.2.3",
     "ember-try": "0.0.6"
   },
   "keywords": [

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -131,6 +131,16 @@ export default class PageObject {
     });
   }
 
+  _assertHasValue(rawSelector, text, bool, message = '') {
+    return this.andThen(() => {
+      message = message || `element with selector: '${this.toSelector(rawSelector)}' containing value: '${text}' ${bool ? 'was found' : 'was not found'}`;
+      const elementValue = this.find(rawSelector).val();
+      const hasValue = elementValue.indexOf(text) > -1;
+
+      this.assert.equal(hasValue, bool, message);
+    });
+  }
+
   assertURL(url = '', message = '') {
     return this.andThen(() => {
       message = message || `current url is: '${url}'`;
@@ -160,6 +170,14 @@ export default class PageObject {
 
   assertNotHasText(rawSelector = '', text = '', message = '') {
     return this._assertHasText(rawSelector, text, false, message);
+  }
+
+  assertHasValue(rawSelector = '', text = '', message = '') {
+    return this._assertHasValue(rawSelector, text, true, message);
+  }
+
+  assertNotHasValue(rawSelector = '', text = '', message = '') {
+    return this._assertHasValue(rawSelector, text, false, message);
   }
 
   andThen(callback) {

--- a/tests/unit/page-object-test.js
+++ b/tests/unit/page-object-test.js
@@ -483,3 +483,57 @@ test('assertNotHasText calls `assert.equal` passing in whether or not the elemen
 
   pageObject.assertNotHasText('some-selector', 'the element doesnt have this text', 'some message');
 });
+
+test('assertHasValue calls `assert.equal` passing in whether or not the element value has the passed in text', function(assert) {
+  assert.expect(5);
+
+  sandbox.stub(window, 'find', () => {
+    const fakeElement = {
+      val() {
+        assert.ok(true, 'value was called on the element returned from find');
+        return 'This is the element value!';
+      }
+    };
+
+    return fakeElement;
+  });
+
+  const mockAssert = {
+    equal(actual, expected, message) {
+      assert.equal(actual, true, 'passed in a bool representing whether or not the element value contained the passed in text');
+      assert.equal(expected, true, 'passes in a bool representing that the value of the element is expected to have the passed in text');
+      assert.equal(message, 'some message', 'passes in an optional message');
+    }
+  };
+
+  const pageObject = new PageObject({ assert: mockAssert });
+
+  pageObject.assertHasValue('some-selector', 'This is the element value!', 'some message');
+});
+
+test('assertNotHasValue calls `assert.equal` passing in whether or not the element value has the passed in text', function(assert) {
+  assert.expect(5);
+
+  sandbox.stub(window, 'find', () => {
+    const fakeElement = {
+      val() {
+        assert.ok(true, 'value was called on the element returned from find');
+        return 'This is the element value!';
+      }
+    };
+
+    return fakeElement;
+  });
+
+  const mockAssert = {
+    equal(actual, expected, message) {
+      assert.equal(actual, false, 'passed in a bool representing whether or not the element value contained the passed in text');
+      assert.equal(expected, false, 'passes in a bool representing that the element value is expected to not have the passed in text');
+      assert.equal(message, 'some message', 'passes in an optional message');
+    }
+  };
+
+  const pageObject = new PageObject({ assert: mockAssert });
+
+  pageObject.assertNotHasValue('some-selector', 'the element doesnt have this value', 'some message');
+});


### PR DESCRIPTION
Often times, we need to assert the value `.val()` of an element contains correct text.  For example, in edit page of a user model, we assert that the user's `name` input has value of the user's name.

``` js
export default class UserEditPage extends PageObject {
  assertInputName(text) {
    return this.assertHasValue('[data-test-target="username"]', text, `username input has value: ${text}`);
  }
}
```

Also, I ran into an error `Rule "disallowVar" is already registered` with `ember-suave@1.0.0`, so I updated to `ember-suave@1.2.3`.
