### PR TITLE
Upgrade ember suave, pin jquery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
+    "jquery": "1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.18.0",
     "sinonjs": "~1.14.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-sinon": "0.2.1",
-    "ember-suave": "1.0.0",
+    "ember-suave": "1.2.3",
     "ember-try": "0.0.6"
   },
   "keywords": [


### PR DESCRIPTION
I just pulled this project and was unable to get tests running. Applying
the follow gets all tests passing.

---

Upgrade ember-suave to 1.2.3
https://github.com/dockyard/ember-suave/issues/84

Fixes:

```
➜  ember-page-object git:(master) ember test
Future versions of Ember CLI will not support v4.3.1. Please update to Node 0.12 or io.js.
version: 1.13.7
Build failed.
Rule "disallowVar" is already registered
AssertionError: Rule "disallowVar" is already registered
```

---

jQuery version pin
https://github.com/emberjs/ember.js/pull/12787

Fixes:

```
Uncaught Error: Assertion Failed: Ember Views require jQuery between 1.7 and 2.1
```
